### PR TITLE
Affichage de pedro_panic.webp dans le README du module D70

### DIFF
--- a/D70_Git/README.md
+++ b/D70_Git/README.md
@@ -123,7 +123,7 @@ Effectuez l'étape 3 de la documentation "[livrez votre travail](../docs/workflo
 Votre copie est maintenant à jour à partir du dépôt principal.
 
 Ajoutez l'image `pedro_panic.webp` ci-dessous :
-![pas Pedro :(](...........)
+![pas Pedro :-(](pedro_panic.webp)
 
 Effectuez l'étape 4 puis 5 de la documentation "[livrez votre travail](../docs/workflow.md)".
 


### PR DESCRIPTION
Ajout de l’image pedro_panic.webp dans le README du dossier D70_Git pour le module D70. Est-ce que tout s’affiche correctement ? 